### PR TITLE
allow using a single/default prefix

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,12 +7,21 @@ function randomAlphaNum() {
 }
 
 var IdGenerator = function(prefixes){
-  this.prefixes = prefixes || [];
-}
+  if (Array.isArray(prefixes)) {
+    this.prefixes = prefixes;
+  }
+  if (typeof prefixes === 'string') {
+    this.prefixes = [prefixes];
+  }
+  this.prefixes = this.prefixes ||  [];
+};
 
 IdGenerator.prototype.new = function(prefix) {
-  if (!(prefix && prefix.length)){
-    throw new Error('missing prefix for id');
+  if (!prefix) {
+    if (this.prefixes.length !== 1) {
+      throw new Error('missing prefix for id');
+    }
+    prefix = this.prefixes[0];
   }
 
   if (this.prefixes.length && !~this.prefixes.indexOf(prefix)){

--- a/test/tests.js
+++ b/test/tests.js
@@ -14,7 +14,9 @@ describe('with no accepted prefix list', function () {
   });
 
   it ('should throw if no prefix is provided', function(){
-    expect(id_generator.new).to.throw(Error, /missing prefix for id/);
+    expect(function () {
+      id_generator.new();
+    }).to.throw(Error, /missing prefix for id/);
   });
 });
 
@@ -32,5 +34,18 @@ describe('with accepted prefix list', function () {
 
   it ('should throw prefix is not in list', function(){
     expect(function() { id_generator.new('cli') }).to.throw(Error, /invalid prefix cli, valid: cus,con/);
+  });
+});
+
+describe('with one accepted prefix', function () {
+  var id_generator;
+  before(function(){
+    id_generator = new IdGenerator('cus');
+  });
+
+  it ('should generate the id with the default prefix', function(){
+    var id = id_generator.new();
+    expect(id).to.have.length(20);
+    expect(id).to.match(/^cus_[a-zA-Z0-9]{16}$/);
   });
 });


### PR DESCRIPTION
It still works as before but now you can use a single prefix:

```
var cusgen = new IdGenerator('cus');
cusgen.new();
```
