### PR TITLE
Fix UID generator

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,7 @@
-var crypto = require('crypto');
-
+var Random = require('random-js');
+var engine = Random.engines.mt19937().autoSeed();
+var distribution = Random.integer(0, 61);
 var ALPHA_NUM = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
-
-function randomAlphaNum() {
-  return ALPHA_NUM[Math.round(Math.random() * (ALPHA_NUM.length - 1))];
-}
 
 var IdGenerator = function(prefixes){
   if (Array.isArray(prefixes)) {
@@ -28,14 +25,12 @@ IdGenerator.prototype.new = function(prefix) {
     throw new Error('invalid prefix ' + prefix + ', valid: ' + this.prefixes);
   }
 
-  var initial = crypto.randomBytes(12).toString('base64').split('');
-  return prefix + '_' + initial.map(function(c){
-    if (c === '/' || c === '+'){
-      return randomAlphaNum();
-    }
+  var id = '';
+  for (var i = 1; i <= 16; i++) {
+    id += ALPHA_NUM[distribution(engine)];
+  }
 
-    return c;
-  }).join('');
+  return prefix + '_' + id;
 };
 
 module.exports = IdGenerator;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-id-generator",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Generates random ids with a prefix (a la Stripe)",
   "main": "lib/index.js",
   "scripts": {
@@ -22,5 +22,8 @@
   "devDependencies": {
     "chai": "^1.10.0",
     "mocha": "^2.1.0"
+  },
+  "dependencies": {
+    "random-js": "^1.0.8"
   }
 }


### PR DESCRIPTION
[This article](https://medium.com/@betable/tifu-by-using-math-random-f1c308c4fd9d#.gpaerhqlc) explains why we have conflicts when generating tokens with
16 chars.

This PR fixes that by using a different RNG. Current implementation used to use
a mix implementation convining Crypto and Math.random to get numbers from an
alphabet. New implementation uses random-js (with mt19937 engine) as random
number generator instead.
