### PR TITLE
Add new API support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,12 +6,47 @@ const IdGenerator = function(prefixes){
   if (Array.isArray(prefixes)) {
     this.prefixes = prefixes;
   }
-  if (typeof prefixes === 'string') {
+  else if (typeof prefixes === 'string') {
     this.prefixes = [prefixes];
+  }
+  else if (typeof prefixes === 'object') {
+    this.prefix = [prefixes.prefix];
+    if(prefixes.len) {
+      this.len = prefixes.len;
+    }
+    else {
+      this.len = 16;
+    }
+    if(prefixes.alphabet) {
+      this.alphabet = prefixes.alphabet;
+    }
+    else {
+      this.alphabet = ALPHA_NUM;
+    }
+  }
+  else {
+    this.len = 16;
+    this.alphabet = ALPHA_NUM;
   }
   this.prefixes = this.prefixes ||  [];
 };
 
+IdGenerator.prototype.get = function() {
+  const rnd = crypto.randomBytes(this.len);
+  const value = new Array(this.len);
+  const charsLength = this.alphabet.length;
+
+  for (var i = 0; i < this.len; i++) {
+    value[i] = this.alphabet[rnd[i] % charsLength];
+  }
+
+  if(this.prefix) {
+    return this.prefix + '_' + value.join('');
+  }
+  else {
+    return value.join('');
+  }
+};
 
 IdGenerator.prototype.newUid = function(len) {
   const rnd = crypto.randomBytes(len);

--- a/test/tests.js
+++ b/test/tests.js
@@ -62,3 +62,42 @@ describe('uid', function () {
     expect(id).to.match(/^[a-zA-Z0-9]{30}$/);
   });
 });
+
+describe('api v1: with length, alphabet and prefix defined', function () {
+  var id_generator;
+  before(function(){
+    id_generator = new IdGenerator({ len: 4, alphabet: 'abcd1234', prefix: 'usr' });
+  });
+
+  it ('should generate the id with the defined prefix, length and alphabet', function(){
+    var id = id_generator.get();
+    expect(id).to.have.length(8);
+    expect(id).to.match(/^usr_[a-d1-4]{4}$/);
+  });
+});
+
+describe('api v1: with length and prefix defined', function () {
+  var id_generator;
+  before(function(){
+    id_generator = new IdGenerator({ len: 4, prefix: 'tkt' });
+  });
+
+  it ('should generate the id with the defined length and prefix and the default alphabet', function(){
+    var id = id_generator.get();
+    expect(id).to.have.length(8);
+    expect(id).to.match(/^tkt_[a-zA-Z0-9]{4}$/);
+  });
+});
+
+describe('api v1: with nothing defined', function () {
+  var id_generator;
+  before(function(){
+    id_generator = new IdGenerator();
+  });
+
+  it ('should generate the id with the default length, prefix and alphabet', function(){
+    var id = id_generator.get();
+    expect(id).to.have.length(16);
+    expect(id).to.match(/^[a-zA-Z0-9]{16}$/);
+  });
+});


### PR DESCRIPTION
Add support for the new API defined in #5 - this is done in a backwards compatible fashion. All old tests still pass, and new tests have been added for the new API definition.